### PR TITLE
fix: add file open error handling

### DIFF
--- a/src/caller.cpp
+++ b/src/caller.cpp
@@ -325,6 +325,11 @@ int main(int argc, char** argv) {
     }
     else {
         in.open(opt->input.c_str(), std::ifstream::in);
+        if (!in.is_open()) {
+            fprintf(stderr, "Error: cannot open file '%s'\n", opt->input.c_str());
+            free(opt);
+            return 1;
+        }
         stream = &in;
     }
 

--- a/tests/test_caller.cpp
+++ b/tests/test_caller.cpp
@@ -1,4 +1,9 @@
 #include <gtest/gtest.h>
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <sys/wait.h>
+#include <unistd.h>
 
 // Placeholder test to verify Google Test infrastructure works
 TEST(InfrastructureTest, PlaceholderTest) {
@@ -9,4 +14,37 @@ TEST(InfrastructureTest, PlaceholderTest) {
 TEST(InfrastructureTest, BasicAssertions) {
     EXPECT_EQ(1 + 1, 2);
     EXPECT_NE(1, 2);
+}
+
+// Test file open error handling
+TEST(FileHandlingTest, NonExistentFileReturnsError) {
+    std::string nonexistent = "/tmp/nonexistent_" + std::to_string(getpid()) + "_" + std::to_string(time(nullptr)) + ".fa";
+    std::string cmd = "./bin/callerpp -i " + nonexistent + " 2>/dev/null";
+    int result = std::system(cmd.c_str());
+    ASSERT_NE(result, -1) << "std::system() failed to execute";
+    ASSERT_TRUE(WIFEXITED(result)) << "Process did not exit normally";
+    EXPECT_NE(WEXITSTATUS(result), 0);
+}
+
+TEST(FileHandlingTest, ValidFileWorks) {
+    // Use unique filename with process ID to avoid race conditions
+    std::string temp_path = "/tmp/test_callerpp_" + std::to_string(getpid()) + ".fa";
+
+    // RAII cleanup guard ensures file is removed even if assertions fail
+    struct FileGuard {
+        std::string path;
+        ~FileGuard() { std::remove(path.c_str()); }
+    } guard{temp_path};
+
+    // Create a temporary test file
+    std::ofstream testfile(temp_path);
+    ASSERT_TRUE(testfile.is_open()) << "Failed to create temporary test file";
+    testfile << ">test\nACGT\nACGT\n";
+    testfile.close();
+
+    std::string cmd = "./bin/callerpp -i " + temp_path + " >/dev/null 2>&1";
+    int result = std::system(cmd.c_str());
+    ASSERT_NE(result, -1) << "std::system() failed to execute";
+    ASSERT_TRUE(WIFEXITED(result)) << "Process did not exit normally";
+    EXPECT_EQ(WEXITSTATUS(result), 0);
 }


### PR DESCRIPTION
## Summary
- Add error handling when opening input files via `-i` option
- Exit with descriptive error message if file cannot be opened

## Background
From code review (`research.md` §1.1, MEDIUM severity):
Previously the program would silently process empty input on file errors because there was no `is_open()` check after opening the file.

## Changes
- `src/caller.cpp`: Add `in.is_open()` check after opening file, return error code 1 with message if failed
- `tests/test_caller.cpp`: Add tests for file handling (non-existent file, valid file)

## Test plan
- [ ] CI workflow passes
- [ ] `./bin/callerpp -i /nonexistent/file` returns error with message

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and reporting for missing or unopenable input files, ensuring proper resource cleanup on failure.

* **Tests**
  * Added comprehensive test suite for file handling scenarios, including validation of error cases with non-existent files and successful operations with valid input files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->