### PR TITLE
fix: remove unused variable (dead code)

### DIFF
--- a/src/caller.cpp
+++ b/src/caller.cpp
@@ -162,9 +162,8 @@ void process(std::unique_ptr<spoa::AlignmentEngine> &alignment_engine, std::stri
         case 1: 
                 std::sort(sequences.begin(), sequences.end(), opt->_compare_lt); 
                 break;
-        case 2: 
-                compare_string_size_gt_t compare_gt;
-                std::sort(sequences.begin(), sequences.end(), opt->_compare_gt); 
+        case 2:
+                std::sort(sequences.begin(), sequences.end(), opt->_compare_gt);
                 break;
         default: 
                 fprintf(stderr, "Bug: resort value '%d' not valid!\n", opt->resort);


### PR DESCRIPTION
## Summary
Remove unused `compare_string_size_gt_t compare_gt` variable.

## Background
From code review (`research.md` §1.4, LOW severity):
The local `compare_gt` object was instantiated but never used. The code uses `opt->_compare_gt` instead.

## Changes
- `src/caller.cpp`: Remove unused variable declaration

## Test plan
- [ ] CI workflow passes
- [ ] Code compiles without warnings

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization: Removed redundant variable declaration in sort functionality. No changes to user-facing behavior or features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->