### PR TITLE
style: remove using namespace std

### DIFF
--- a/src/caller.cpp
+++ b/src/caller.cpp
@@ -7,7 +7,6 @@
 #include <getopt.h>
 #include "spoa/spoa.hpp"
 #include "spoa/alignment_engine.hpp"
-using namespace std;
 
 #define PACKAGE_VERSION "0.1.7-dev"
 


### PR DESCRIPTION
## Summary
Remove `using namespace std;` directive to avoid global namespace pollution.

## Background
From code review (`research.md` §3.3, LOW severity):
Bringing all std symbols into global namespace can cause name collisions.

## Changes
- `src/caller.cpp`: Remove `using namespace std;` line

The code already uses explicit `std::` prefixes for all standard library types, so this change is safe.

## Test plan
- [ ] CI workflow passes
- [ ] Code compiles successfully

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)