### PR TITLE
perf: remove unnecessary string copy in MSA output

### DIFF
--- a/src/caller.cpp
+++ b/src/caller.cpp
@@ -242,8 +242,7 @@ void process(std::unique_ptr<spoa::AlignmentEngine> &alignment_engine, std::stri
         // left align if necessary
         if (opt->left_align) left_align_msa(msa);
         for (const auto& it: msa) {
-            std::string sequence = it;
-            fprintf(stdout, "%s\n", sequence.c_str());
+            fprintf(stdout, "%s\n", it.c_str());
         }
     }
 }


### PR DESCRIPTION
## Summary
Remove unnecessary string copy when outputting MSA sequences.

## Background
From code review (`research.md` §2.1, LOW severity):
The code was copying each string to a local variable before calling c_str().

## Changes
- `src/caller.cpp`: Use `it.c_str()` directly instead of copying to a new string

## Test plan
- [ ] CI workflow passes
- [ ] MSA output unchanged

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal code for improved efficiency with no change to user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->