### PR TITLE
docs: fix typos in comments

### DIFF
--- a/src/caller.cpp
+++ b/src/caller.cpp
@@ -76,7 +76,7 @@ void left_align(std::string &consensus, std::string &sequence) {
 
     int left = 0;
     while(left < msa_size) {
-        // find the left-moset '-' in a run of '-'
+        // find the left-most '-' in a run of '-'
         if (sequence[left] != '-') {
             left++;
             continue;
@@ -183,11 +183,11 @@ void process(std::unique_ptr<spoa::AlignmentEngine> &alignment_engine, std::stri
 
     std::string consensus;
     if (opt->pairwise_msa) {
-        // generate the consenuss
+        // generate the consensus
         consensus = graph.GenerateConsensus();
-        // add the consenuss to the list of sequences
+        // add the consensus to the list of sequences
         sequences.insert(sequences.begin(), consensus);
-        // create a enw graph for the second round of alignment
+        // create a new graph for the second round of alignment
         graph = spoa::Graph();
         // add the alignments to the graph, including the consensus!
         for (const auto& it: sequences) {


### PR DESCRIPTION
## Summary
Fix typos in code comments.

## Background
From code review (`research.md` §5):

## Changes
- `src/caller.cpp`:
  - "left-moset" → "left-most"
  - "consenuss" → "consensus" (two occurrences)
  - "enw" → "new"

## Test plan
- [ ] CI workflow passes

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected typos and terminology inconsistencies in internal comments.

---

**Note:** This release contains no functional changes or user-facing updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->